### PR TITLE
Updated package.json with peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngrx-event-bus",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "description": "RxJS event bus with Mediator Pattern",
   "author": "PixelByAJ",
   "repository": {
@@ -28,6 +28,11 @@
     "e2e": "ng e2e"
   },
   "private": true,
+  "peerDependencies": {
+    "@angular/common": "^8.2.10",
+    "@angular/core": "^8.2.10",
+    "rxjs": "^6.4.0"
+  },
   "dependencies": {
     "@angular/animations": "^8.2.10",
     "@angular/common": "^8.2.10",


### PR DESCRIPTION
While testing with RunKit (from npm package's home page - https://www.npmjs.com/package/ngrx-event-bus), it fails for rxjs.
Getting below error message:
> Error: Cannot find module 'rxjs'
> Should we have rxjs?
> We should have every package on npm. Sometimes this error is caused by a typo in your require path, but if you think we are actually missing this package, please confirm below and we’ll do our best to fix it as soon as possible!
> Report 'rxjs' as missing

After publishing the package with updated package.json, this will be fixed.