### PR TITLE
Updated package.json with peerDependencies

### DIFF
--- a/projects/ngrx-event-bus/package.json
+++ b/projects/ngrx-event-bus/package.json
@@ -21,6 +21,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@angular/common": "^8.2.9",
-    "@angular/core": "^8.2.9"
+    "@angular/core": "^8.2.9",
+    "rxjs": "~6.4.0"
   }
 }


### PR DESCRIPTION
While testing with RunKit (from npm package's home page - https://www.npmjs.com/package/ngrx-event-bus), it fails for rxjs.
Getting below error message:

> Error: Cannot find module 'rxjs'
> Should we have rxjs?
> We should have every package on npm. Sometimes this error is caused by a typo in your require path, but if you think we are actually missing this package, please confirm below and we’ll do our best to fix it as soon as possible!
> Report 'rxjs' as missing

After publishing the package with updated package.json, this will be fixed.